### PR TITLE
Remove anaconda and create script to create /etc/vbox/networks.conf

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -41,27 +41,23 @@ Vagrant.configure("2") do |config|
     server.vm.hostname = "webserver"
     server.vm.provision "shell", privileged: false, inline: <<-SHELL
         export DB_IP="192.168.56.2"
-
-        echo "Installing Anaconda..."
-        sudo wget https://repo.anaconda.com/archive/Anaconda3-2019.07-Linux-x86_64.sh -O $HOME/Anaconda3-2019.07-Linux-x86_64.sh
-    
-        bash $HOME/Anaconda3-2019.07-Linux-x86_64.sh -b
         
-        echo ". $HOME/.bashrc" >> $HOME/.bash_profile
-        echo "export PATH=$HOME/anaconda3/bin:$PATH" >> $HOME/.bash_profile
-        export PATH="$HOME/anaconda3/bin:$PATH"
-        rm $HOME/Anaconda3-2019.07-Linux-x86_64.sh
-        source $HOME/.bash_profile
-
-        pip install Flask-PyMongo
-
+        python3 --version
         cp -r /vagrant/* $HOME
-        nohup python minitwit.py > out.log 2>&1 &
+        
+        sudo apt-get install -y python3 python3-pip
+        
+        python3 -m pip install -r requirements.txt
+        python3 -m pip install Flask-PyMongo
+        
+        nohup python3 minitwit.py > out.log 2>&1 &
+        
+        ip=$(ifconfig eth1 | awk -F ' *|:' '/inet /{print $3}')
+        
         echo "================================================================="
         echo "=                            DONE                               ="
         echo "================================================================="
-        echo "Navigate in your browser to:"
-        echo "http://192.168.56.3:5000"
+        echo "Navigate in your browser to: $ip:5000"
     SHELL
   end
 

--- a/vbox-network.sh
+++ b/vbox-network.sh
@@ -1,0 +1,31 @@
+# If /etc/vbox doesn't exist create it
+if [ ! -d /etc/vbox ]; then
+    echo "Creating /etc/vbox"
+    mkdir /etc/vbox
+fi
+
+# if file /etc/vbox/networks.conf doesn't exist create it
+if [ ! -f /etc/vbox/networks.conf ]; then
+    echo "Creating /etc/vbox/networks.conf"
+    touch /etc/vbox/networks.conf
+fi
+
+# if file /etc/vbox/networks.conf doesn't contain "* 172.28.128.0/16" add it
+if ! grep -q "* 172.28.128.0/16" /etc/vbox/networks.conf; then
+    echo "Adding '* 172.28.128.0/16' to /etc/vbox/networks.conf"
+    echo "* 172.28.128.0/16" > /etc/vbox/networks.conf
+fi
+
+# if file /etc/vbox/networks.conf doesn't contain "* 172.28.128.0/16" add it
+if ! grep -q "* 172.28.128.0/16" /etc/vbox/networks.conf; then
+    echo "Adding '* 172.28.128.0/16' to /etc/vbox/networks.conf"
+    echo "* 172.28.128.0/16" >> /etc/vbox/networks.conf
+fi
+
+# if file /etc/vbox/networks.conf doesn't contain "* 192.168.20.0/16" add it
+# This is necessary for the client network
+if ! grep -q "* 192.168.20.0/16" /etc/vbox/networks.conf; then
+    echo "Adding '* 192.168.20.0/16' to /etc/vbox/networks.conf"
+    echo "* 192.168.20.0/16" >> /etc/vbox/networks.conf
+fi
+


### PR DESCRIPTION
## VirtualBox network error
Due to a recent update to VirtualBox it can no longer create virtual networks without allowing the ip range in `/etc/vbox/networks.conf` so i added a script to create that file with the necessary ip's in it.

Run it with
```bash
chmod +x vbox-network.sh
sudo ./vbox-network.sh # Must be run with sudo as /etc is protected
``` 

## Anaconda error
Running `vagrant up` caused the following error:
```
webserver: WARNING conda.core.envs_manager:register_env(46): Unable to register environment. Path not writable or missing.
    webserver:   environment location: /home/vagrant/anaconda3
    webserver:   registry file: /home/vagrant/.conda/environments.txt
```

Which resulted in it not installing python and pip. Therefore i just bypassed it by directly installing python and pip, since it's a isolated reproducible environment that should be fine.


## Appendinx
Virtual box error:
```
There was an error while executing `VBoxManage`, a CLI used by Vagrant
for controlling VirtualBox. The command and stderr is shown below.

Command: ["hostonlyif", "ipconfig", "vboxnet2", "--ip", "172.28.128.1", "--netmask", "255.255.255.0"]

Stderr: VBoxManage: error: Code E_ACCESSDENIED (0x80070005) - Access denied (extended info not available)
VBoxManage: error: Context: "EnableStaticIPConfig(Bstr(pszIp).raw(), Bstr(pszNetmask).raw())" at line 242 of file VBoxManageHostonly.cpp
```

Same for the client:
```
There was an error while executing `VBoxManage`, a CLI used by Vagrant
for controlling VirtualBox. The command and stderr is shown below.

Command: ["hostonlyif", "ipconfig", "vboxnet2", "--ip", "192.168.20.1", "--netmask", "255.255.255.0"]

Stderr: VBoxManage: error: Code E_ACCESSDENIED (0x80070005) - Access denied (extended info not available)
VBoxManage: error: Context: "EnableStaticIPConfig(Bstr(pszIp).raw(), Bstr(pszNetmask).raw())" at line 242 of file VBoxManageHostonly.cpp
```